### PR TITLE
fix: real (non-jsonb) based indexing on timestamp

### DIFF
--- a/acr/embedded_spec.go
+++ b/acr/embedded_spec.go
@@ -492,6 +492,11 @@ func init() {
         "result": {
           "x-go-custom-tag": "gorm:\"type:jsonb;\"",
           "$ref": "#/definitions/Webhook"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:time;index;\""
         }
       }
     },
@@ -1134,6 +1139,11 @@ func init() {
         "result": {
           "x-go-custom-tag": "gorm:\"type:jsonb;\"",
           "$ref": "#/definitions/Webhook"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:time;index;\""
         }
       }
     },

--- a/models/result.go
+++ b/models/result.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // Result result
@@ -21,6 +22,10 @@ type Result struct {
 
 	// result
 	Result *Webhook `json:"result,omitempty" gorm:"type:jsonb;"`
+
+	// timestamp
+	// Format: date-time
+	Timestamp strfmt.DateTime `json:"timestamp,omitempty" gorm:"type:time;index;"`
 }
 
 // Validate validates this result
@@ -28,6 +33,10 @@ func (m *Result) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateResult(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTimestamp(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -50,6 +59,19 @@ func (m *Result) validateResult(formats strfmt.Registry) error {
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *Result) validateTimestamp(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Timestamp) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("timestamp", "body", "date-time", m.Timestamp.String(), formats); err != nil {
+		return err
 	}
 
 	return nil

--- a/swagger.yml
+++ b/swagger.yml
@@ -170,6 +170,10 @@ definitions:
       result:
         $ref: '#/definitions/Webhook'
         x-go-custom-tag: gorm:"type:jsonb;"
+      timestamp:
+        type: "string"
+        format: "date-time"
+        x-go-custom-tag: gorm:"type:time;index;"
   Webhook:
     type: "object"
     properties:


### PR DESCRIPTION
the timestamp_utc field was used in almost every query and it was very
slow since it needed quite some casting to get useable answers. this
makes inserting a bit costlier while making querying dirt cheap